### PR TITLE
Method to filter for specific abstracts

### DIFF
--- a/models/contribution.py
+++ b/models/contribution.py
@@ -41,6 +41,7 @@ class Contribution(FilteredModel):
     contact_email: str
     title: str
     content: str
+    state: str
 
     @property
     def contribution_type(self):
@@ -78,7 +79,8 @@ class Contribution(FilteredModel):
             questionnaire=questionnaire,
             contact_email=contact_email,
             title=json_content["title"],
-            content=json_content["content"]
+            content=json_content["content"],
+            state=json_content["state"]
         )
 
     def to_md(self, template=None):

--- a/models/contribution.py
+++ b/models/contribution.py
@@ -71,7 +71,7 @@ class Contribution(FilteredModel):
             if person is not None:
                 persons.append(person)
         return Contribution(
-            id=json_content["id"],
+            id=json_content["friendly_id"],
             allow_list=allow_list,
             submission_date=json_content["submitted_dt"],
             acceptance_date=None,

--- a/models/questionnaire.py
+++ b/models/questionnaire.py
@@ -29,7 +29,8 @@ class Questionnaire(FilteredModel):
         # load contents of diversity  questions
         diversity_questions = DiversityQuestions.from_json(allow_list, custom_fields)
         # load contribution questions
-        contribution_questions = contribution_type_map.get(json_content["submitted_contrib_type"]["name"]).from_json(allow_list, custom_fields)
+        contribution_questions = contribution_type_map.get(
+            json_content["submitted_contrib_type"]["name"]).from_json(allow_list, custom_fields)
         keys = list(custom_fields.keys())
         return Questionnaire(
             allow_list=allow_list,
@@ -218,4 +219,5 @@ class WorkshopContriubtion(ContributionQuestions):
 
 contribution_type_map = {
     "Talk": TalkContribution,
+    "Software Demonstration": SoftwareContribution
 }

--- a/sorse_data_filter.py
+++ b/sorse_data_filter.py
@@ -27,22 +27,36 @@ def filter_data(input, workflow, output_path):
         workflow_data = config_data.get(workflow)
     json_data = json.load(input)
     abstracts = json_data["abstracts"]
+    workflow_filter = workflow_data["filter"]
+    assert isinstance(workflow_filter, dict)
     for abstract in abstracts:
         abstract["custom_fields"] = flatten_custom_fields(abstract["custom_fields"])
         contribution = Contribution.from_json(
             workflow_data["allow_list"]["contribution"], abstract)
-        format_parameters = [
-            traverse_into(
-                parameter.split("."),
-                contribution=contribution,
-                output_type=workflow_data["output_type"])
-            for parameter in workflow_data["output_format_arguments"]]
-        output_file = os.path.join(output_path, workflow_data["output_format_string"].format(*format_parameters))
-        # prepare output path
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
-        with open(output_file, "w") as output:
-            output.write(contribution.to_md(template=workflow_data["output_template"]))
-            click.echo(f"created file at {output_file}")
+        if check_filter(workflow_filter, contribution=contribution):
+            format_parameters = [
+                traverse_into(
+                    parameter.split("."),
+                    contribution=contribution,
+                    output_type=workflow_data["output_type"])
+                for parameter in workflow_data["output_format_arguments"]]
+            output_file = os.path.join(output_path, workflow_data["output_format_string"].format(*format_parameters))
+            # prepare output path
+            os.makedirs(os.path.dirname(output_file), exist_ok=True)
+            with open(output_file, "w") as output:
+                output.write(contribution.to_md(template=workflow_data["output_template"]))
+                click.echo(f"created file at {output_file}")
+
+
+def check_filter(filter, **namespace):
+    key = next(iter(filter.keys()))
+    head = namespace[key]
+    for key, value in filter[key].items():
+        if isinstance(value, dict):
+            head = getattr(head, key)
+        else:
+            return getattr(head, key) == value
+    return False
 
 
 def traverse_into(name, **namespace):

--- a/templates/website.md
+++ b/templates/website.md
@@ -1,5 +1,5 @@
 ---
-title: {{ contribution.title }}
+title: "{{ contribution.title }}"
 {%- if contribution.persons|length > 0 %}
 authors:
 {%- for person in contribution.persons %}
@@ -24,13 +24,13 @@ category: {{ contribution.contribution_type }}
 language: {{ contribution.questionnaire.language }}
 {%- endif %}
 {%- if contribution.questionnaire.prerequisite_knowledge %}
-prerequisites: {{ contribution.questionnaire.prerequisite_knowledge }}
+prerequisites: "{{ contribution.questionnaire.prerequisite_knowledge }}"
 {%- endif %}
 {%- if contribution.questionnaire.contribution_questions.license %}
 license: {{ contribution.questionnaire.contribution_questions.license }}
 {%- endif %}
 {%- if contribution.questionnaire.contribution_questions.installation_instructions %}
-instructions: contribution.questionnaire.contribution_questions.installation_instructions
+instructions: "{{ contribution.questionnaire.contribution_questions.installation_instructions }}"
 {%- endif %}
 {%- if contribution.questionnaire.contribution_questions.panelists %}
 panelists: {{ contribution.questionnaire.contribution_questions.panelists }}

--- a/workflows.yaml
+++ b/workflows.yaml
@@ -24,7 +24,7 @@ website:
           - license
           - maximum_number_participants
   output_type: md
-  output_format_string: "{}/event-{}.{}"
+  output_format_string: "{}/event-{:03d}.{}"
   output_format_arguments:
     - contribution.contribution_type
     - contribution.id

--- a/workflows.yaml
+++ b/workflows.yaml
@@ -1,4 +1,7 @@
 website:
+  filter:
+    contribution:
+      state: accepted
   allow_list:
     contribution:
       - title


### PR DESCRIPTION
This PR enables adding filter conditions into the config file as mentioned in #10. A filter is now applied to the website workflow to only send abstracts that are in *accepted* state.
Further, this PR fixes some formatting issues in the website template.

Closes #10.