### PR TITLE
update software_demo contribution type

### DIFF
--- a/models/questionnaire.py
+++ b/models/questionnaire.py
@@ -179,7 +179,7 @@ class PosterContribution(ContributionQuestions):
 class SoftwareContribution(ContributionQuestions):
     installation_instructions: str
     license: str
-    contribution_type = "software"
+    contribution_type = "software_demo"
 
     @classmethod
     def from_json(cls, allow_list: Sequence, json_content):


### PR DESCRIPTION
Just a small change of the contribution_type of software demos to match https://github.com/SORSE/sorse.github.io/blob/master/_data/committee/programme_teams.yml