### PR TITLE
Fix yaml alias syntax

### DIFF
--- a/templates/website.md
+++ b/templates/website.md
@@ -3,7 +3,13 @@ title: "{{ contribution.title }}"
 {%- if contribution.persons|length > 0 %}
 authors:
 {%- for person in contribution.persons %}
-    - {% if speaker == nil and person.is_speaker -%}{% set speaker = person %}&speaker {% endif -%}name: {{ person.title }} {{ person.first_name }} {{ person.last_name }}
+{%- if speaker == nil and person.is_speaker %}
+{%- set speaker = person %}
+    - &speaker
+      name: {{ person.title }} {{ person.first_name }} {{ person.last_name }}
+{%- else %}
+    - name: {{ person.title }} {{ person.first_name }} {{ person.last_name }}
+{%- endif %}
 {%- if person.email %}
       email: {{ person.email }}
 {%- endif %}


### PR DESCRIPTION
As mentioned in #21 the encoding of aliases was currently not correct. This is fixed with this PR so that information are rendered as follows:

```yaml
---
title: "Towards Knowledge Graphs of Research Software metadata"
authors:
    - &speaker
      name:  Daniel Garijo
      email: dgarijo@isi.edu
      orcid: 0000-0003-0454-7145
      is_speaker: true
      affiliation: 1
    - name:  Yolanda Gil
      affiliation: 1
---
```

Closes #21.