### PR TITLE
Fix text encoding

### DIFF
--- a/models/contribution.py
+++ b/models/contribution.py
@@ -10,7 +10,7 @@ from models.affiliation import Affiliation
 from models.person import Person
 from models.questionnaire import Questionnaire
 from utils import load_orcid_information, find_custom_fields_key, create_template, \
-    to_float, traverse_into, load_allow_list
+    to_float, traverse_into, load_allow_list, to_title, to_text
 
 ORCID_ID_PATTERN = re.compile(r"\d{4}-\d{4}-\d{4}-\d{4}")
 with open("./contributions.yaml") as stream:
@@ -89,8 +89,8 @@ class Contribution(FilteredModel):
             persons=persons,
             questionnaire=questionnaire,
             contact_email=contact_email,
-            title=json_content["title"],
-            content=json_content["content"],
+            title=to_title(json_content["title"]),
+            content=to_text(json_content["content"]),
             state=json_content["state"],
             score=to_float(json_content["score"]),
         )

--- a/models/questionnaire.py
+++ b/models/questionnaire.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Sequence,  ClassVar
 
 from models import FilteredModel
-from utils import to_bool, find_custom_fields_key, to_str, load_allow_list
+from utils import to_bool, find_custom_fields_key, to_str, load_allow_list, to_text
 
 
 @dataclass
@@ -42,7 +42,8 @@ class Questionnaire(FilteredModel):
             agreement_email_publication=to_bool(custom_fields.get(find_custom_fields_key(keys, "contact email is published"), None)),
             language=to_str(custom_fields.get("Language", None)),
             topic_bazaar=to_bool(custom_fields.get("Topic Bazaar", None)),
-            prerequisite_knowledge=to_str(custom_fields.get("Prerequisite knowledge", None)),
+            prerequisite_knowledge=to_text(
+                to_str(custom_fields.get("Prerequisite knowledge", None))),
             relevance=to_str(custom_fields.get("Relevance to the community", None)),
             earliest_delivery=custom_fields.get("Earliest delivery date", None),
             latest_delivery=custom_fields.get("Latest delivery date", None),
@@ -186,7 +187,7 @@ class SoftwareContribution(ContributionQuestions):
     def from_json(cls, allow_list: Sequence, json_content):
         return SoftwareContribution(
             allow_list=allow_list,
-            installation_instructions=to_str(json_content.get("[SOFTWARE DEMOS ONLY] Installation instructions", None)),
+            installation_instructions=to_text(to_str(json_content.get("[SOFTWARE DEMOS ONLY] Installation instructions", None))),
             license=to_str(json_content.get("[SOFTWARE DEMOS ONLY] Software licence", None)),
         )
 

--- a/models/questionnaire.py
+++ b/models/questionnaire.py
@@ -29,17 +29,27 @@ class Questionnaire(FilteredModel):
         # load contents of diversity  questions
         diversity_questions = DiversityQuestions.from_json(allow_list, custom_fields)
         # load contribution questions
-        contribution_question_allow_list = load_allow_list("contribution_questions", allow_list)
+        contribution_question_allow_list = load_allow_list(
+            "contribution_questions", allow_list)
         contribution_questions = contribution_type_map.get(
-            json_content["submitted_contrib_type"]["name"]).from_json(contribution_question_allow_list, custom_fields)
+            json_content["submitted_contrib_type"]["name"]).from_json(
+            contribution_question_allow_list, custom_fields)
         keys = list(custom_fields.keys())
         return Questionnaire(
             allow_list=allow_list,
-            agreement_zenodo_publication=to_bool(custom_fields.get(find_custom_fields_key(keys, "Zenodo"), None)),
-            agreement_recording_publication=to_bool(custom_fields.get(find_custom_fields_key(keys, "recording published"), None)),
-            agreement_cc_by_publication=to_bool(custom_fields.get(find_custom_fields_key(keys, "CC-BY 4.0"), None)),
-            agreement_email_contact=to_bool(custom_fields.get(find_custom_fields_key(keys, "agree to be contacted by email"), None)),
-            agreement_email_publication=to_bool(custom_fields.get(find_custom_fields_key(keys, "contact email is published"), None)),
+            agreement_zenodo_publication=to_bool(
+                custom_fields.get(find_custom_fields_key(keys, "Zenodo"), None)),
+            agreement_recording_publication=to_bool(
+                custom_fields.get(find_custom_fields_key(
+                    keys, "recording published"), None)),
+            agreement_cc_by_publication=to_bool(
+                custom_fields.get(find_custom_fields_key(keys, "CC-BY 4.0"), None)),
+            agreement_email_contact=to_bool(
+                custom_fields.get(find_custom_fields_key(
+                    keys, "agree to be contacted by email"), None)),
+            agreement_email_publication=to_bool(
+                custom_fields.get(find_custom_fields_key(
+                    keys, "contact email is published"), None)),
             language=to_str(custom_fields.get("Language", None)),
             topic_bazaar=to_bool(custom_fields.get("Topic Bazaar", None)),
             prerequisite_knowledge=to_text(
@@ -48,7 +58,8 @@ class Questionnaire(FilteredModel):
             earliest_delivery=custom_fields.get("Earliest delivery date", None),
             latest_delivery=custom_fields.get("Latest delivery date", None),
             multiple_deliveries=to_bool(custom_fields.get("Multiple deliveries", None)),
-            main_author_job_title=to_str(custom_fields.get("Main author job title", None)),
+            main_author_job_title=to_str(
+                custom_fields.get("Main author job title", None)),
             diversity_questions=diversity_questions,
             contribution_questions=contribution_questions,
         )

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,18 @@ import jinja2
 import requests
 
 
+TEXT_REPLACEMENTS = {
+    "‘": "'",
+    "’": "'",
+    "“": '"',
+    "”": '"',
+    "–": "--",
+}
+TITLE_REPLACEMENTS = {
+    "&": "and"
+}
+
+
 def load_allow_list(name: str, allow_list: Sequence) -> Sequence:
     for elem in allow_list:
         if isinstance(elem, dict):
@@ -40,6 +52,23 @@ def to_str(value: str, default: Optional[str] = None) -> Optional[str]:
     if value is None or "none" == value.lower():
         return default
     return value
+
+
+def to_text(value: str) -> Optional[str]:
+    """Function ensures proper encoding of entities"""
+    return replace_text(value, TEXT_REPLACEMENTS)
+
+
+def to_title(value:  str) -> Optional[str]:
+    """Function  ensures proper encoding of titles"""
+    return replace_text(value, TITLE_REPLACEMENTS)
+
+
+def replace_text(text: str, replacements: Dict[str, str]) -> Optional[str]:
+    if text:
+        for old, replacement in replacements.items():
+            text = text.replace(old, replacement)
+    return text
 
 
 def to_bool(value: str, default: bool = False) -> bool:


### PR DESCRIPTION
This PR fixes issues with the encoding of texts. I decided not to use entities but instead the simple chars and for ndashs ``--``. 
As those data is running through pandoc I expect the best results for different outputs with those simple chars.
However, the concept is currently build around a replacement dictionary. So we can at any time easily change the corresponding replacements.

Replacements are applied to ``title``, ``content``, ``prerequisite_knowledge``, and ``installation_instructions``.

The following replacements are currently implemented:

```python
TEXT_REPLACEMENTS = {
    "‘": "'",
    "’": "'",
    "“": '"',
    "”": '"',
    "–": "--",
}
TITLE_REPLACEMENTS = {
    "&": "and"
}
```