### PR TITLE
Add publication date to website export

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -1,0 +1,2 @@
+def datetimeformat(value, format='%Y-%m-%d'):
+    return value.strftime(format)

--- a/models/contribution.py
+++ b/models/contribution.py
@@ -108,10 +108,11 @@ class Contribution(FilteredModel):
             worksheet.append_row([traverse_into(value.split("."), contribution=contribution) for value in header_data.values()])
 
     def to_md(self, template=None):
+        from sorse_data_filter import META
         contribution = self.to_json()
 
         template_renderer = create_template(template)
-        return template_renderer.render(contribution=contribution)
+        return template_renderer.render(contribution=contribution, meta=META)
 
     def __repr__(self):
         return f"{self.__class__.__name__}(id='{self.id}', " \

--- a/models/meta.py
+++ b/models/meta.py
@@ -1,0 +1,10 @@
+import datetime
+from pytz import timezone
+
+
+class Meta:
+    current_date: datetime.datetime
+
+    def __init__(self):
+        utc = timezone("UTC")
+        self.current_date = datetime.datetime.now(tz=utc)

--- a/sorse_data_filter.py
+++ b/sorse_data_filter.py
@@ -6,9 +6,12 @@ import yaml
 from dotenv import load_dotenv
 
 from models.contribution import Contribution
+from models.meta import Meta
 from utils import flatten_custom_fields, traverse_into
 
 load_dotenv()
+
+META = Meta()
 
 
 @click.group()

--- a/templates/website.md
+++ b/templates/website.md
@@ -48,5 +48,7 @@ instructions: "{{ contribution.questionnaire.contribution_questions.installation
 {%- if contribution.questionnaire.contribution_questions.panelists %}
 panelists: {{ contribution.questionnaire.contribution_questions.panelists }}
 {%- endif %}
+date: {{ meta.current_date | datetimeformat("%Y-%m-%d") }}
 ---
 {{ contribution.content }}
+

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@ from typing import Iterable, Optional, Dict, Sequence
 import jinja2
 import requests
 
+from filters import datetimeformat
 
 TEXT_REPLACEMENTS = {
     "‘": "'",
@@ -38,6 +39,7 @@ def traverse_into(name, **namespace):
 def create_template(template_file):
     templateLoader = jinja2.FileSystemLoader(searchpath="./templates")
     templateEnv = jinja2.Environment(loader=templateLoader)
+    templateEnv.filters['datetimeformat'] = datetimeformat
     template = templateEnv.get_template(template_file)
     return template
 


### PR DESCRIPTION
This PR adds publication ``date`` to the website export of contributions. This includes:

* filter for Jinja2 enabling the formatting of ``datetime`` objects,
* creating global ``META`` object containing information such as ``datetime``, and
* the adaptation to the website template.

Closes #25.