### PR TITLE
Handling of speaker references

### DIFF
--- a/templates/website.md
+++ b/templates/website.md
@@ -2,9 +2,11 @@
 title: "{{ contribution.title }}"
 {%- if contribution.persons|length > 0 %}
 authors:
+{%- set ns = namespace(speaker=false) -%}
+{%- set ns.speaker = None -%}
 {%- for person in contribution.persons %}
-{%- if speaker == nil and person.is_speaker %}
-{%- set speaker = person %}
+{%- if ns.speaker is none and person.is_speaker %}
+{%- set ns.speaker = person %}
     - &speaker
       name: {{ person.title }} {{ person.first_name }} {{ person.last_name }}
 {%- else %}


### PR DESCRIPTION
As mentioned in #33 currently for all authors that were also considered speakers received the `speaker` alias.  As this cannot be processed via YAML, only the first appearance of a speaker should be considered as the alias. This is fixed by the current PR by introducing a namespace variable for `speaker` as otherwise assignments to the variable were dropped due to scoping in Jinja2. The namespace prevents this and we get the intended behaviour now.

Closes #33.