### PR TITLE
Some changes for displaying names for website

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -13,7 +13,7 @@ def extendlinks(value):
     return value
 
 
-def titlefilter(title, reject_list=["Mr.", "Ms.", "Mrs."]):
+def titlefilter(title, reject_list=("Mr.", "Ms.", "Mrs.")):
     if title in reject_list:
         title = ""
     return title

--- a/filters.py
+++ b/filters.py
@@ -11,3 +11,9 @@ def extendlinks(value):
     if value:
         value = URL_PATTERN.sub(r"<a href='\g<0>' class='truncated'>\g<0></a>", value)
     return value
+
+
+def titlefilter(title, reject_list=["Mr.", "Ms.", "Mrs."]):
+    if title in reject_list:
+        title = ""
+    return title

--- a/templates/website.md
+++ b/templates/website.md
@@ -6,9 +6,9 @@ authors:
 {%- if speaker == nil and person.is_speaker %}
 {%- set speaker = person %}
     - &speaker
-      name: {{ person.title }} {{ person.first_name }} {{ person.last_name }}
+      name: {{ (person.title | titlefilter + " " + person.first_name + " " + person.last_name) | trim }}
 {%- else %}
-    - name: {{ person.title }} {{ person.first_name }} {{ person.last_name }}
+    - name: {{ (person.title | titlefilter + " " + person.first_name + " " + person.last_name) | trim }}
 {%- endif %}
 {%- if person.email %}
       email: {{ person.email }}

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ from typing import Iterable, Optional, Dict, Sequence
 import jinja2
 import requests
 
-from filters import datetimeformat, extendlinks
+from filters import datetimeformat, extendlinks, titlefilter
 
 TEXT_REPLACEMENTS = {
     "‘": "'",
@@ -43,6 +43,7 @@ def create_template(template_file):
     templateEnv = jinja2.Environment(loader=templateLoader)
     templateEnv.filters['extendlinks'] = extendlinks
     templateEnv.filters['datetimeformat'] = datetimeformat
+    templateEnv.filters['titlefilter'] = titlefilter
     template = templateEnv.get_template(template_file)
     return template
 


### PR DESCRIPTION
Until now sometimes titles such as *Mr.*, *Mrs.*, or *Ms.* got through to the website. We further had some whitespace issues due to concatenation of title, first and last name. This is fixed in this PR.